### PR TITLE
Fixed two GCC warnings during KmerCo compilation

### DIFF
--- a/KmerCo.c
+++ b/KmerCo.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <time.h>
 #include <string.h>
 #include <math.h>
@@ -8,14 +9,14 @@
 #include "KmerCo.h" //KmerCo header file
 #include "initBF.h"
 #include <sys/mman.h>
-#include<fcntl.h>
+#include <fcntl.h>
 
 static unsigned long int TP=0,TN=0,FP=0;
 
 unsigned long int **aBF;
 
 //#### Insertion without file writing (Canonical) ##########
-void insertion_canonical_without_filewrite(char fname[6][100],int kmer_len,int threshold, int k){
+void insertion_canonical_without_filewrite(char fname[5][100],int kmer_len,int threshold, int k){
 	int result,kcount=0,rcount=0;
     char ch,kmer[kmer_len+1],rev_kmer[kmer_len+1];	
 	double err=0.001;
@@ -129,7 +130,7 @@ void insertion_canonical_without_filewrite(char fname[6][100],int kmer_len,int t
 }	
 
 //#### Insertion with file writing (Canonical) ##########
-void insertion_canonical_with_filewrite(char fname[6][100],int kmer_len,int threshold, int k){
+void insertion_canonical_with_filewrite(char fname[5][100],int kmer_len,int threshold, int k){
 	int result,kcount=0,rcount=0;
     char ch,kmer[kmer_len+1],rev_kmer[kmer_len+1];
 	double err=0.001;


### PR DESCRIPTION
### Description of the changes:

The commit under this pull request fixes the issues that led to the two GCC warnings during compilation of KmerCo: 

- **Implicit function declaration warning for `close()`** (`-Wimplicit-function-declaration`)
-  **Accessing 600 bytes in a region of size 500** (`-Wstringop-overflow=`) for each of the two canonical insertion functions

For the implicit function declaration warning for close(), we have included the `unistd.h` header file that fixes the issue. 

For the array access size warning, we rectified the relevant arguments of the canonical insertion functions that corrects the issue. Specifically, we changed the parameter `char fname [6][100]` to `char fname [5][100]`, since the `fname` array that is given as input later on during execution only has 5 elements and not 6.

### Before and after (screenshots): 

Output of GCC compilation before implementing the changes, three warnings in total:

>![Before](https://github.com/patgiri/KmerCo/assets/125729402/78af7498-7458-4d77-ab44-09d26a4ff011)


Output of GCC compilation after implementing the changes, successful compilation without warnings:

>![After](https://github.com/patgiri/KmerCo/assets/125729402/d2983d91-610a-477e-b045-d2ab67f9ec27)

### Commit Authors:

- Preetodeep Dev (@papa-delta)
- Swayampakula Kedharnath (@SWAYAMPAKULA-KEDHARNATH)



